### PR TITLE
Titles and Descriptions kept together on the same page

### DIFF
--- a/lib/pdf_content.rb
+++ b/lib/pdf_content.rb
@@ -22,13 +22,15 @@ def content( category )
 
     @event_types.each_with_index do |event_type, index|
 
-      @pdf.text "<link href='#{full_uri(event_type)}'>#{event_type.name}</link>",
-        :size => 12,
-        :inline_format => true
+      @pdf.group do
+        @pdf.text "<link href='#{full_uri(event_type)}'>#{event_type.name}</link>",
+          :size => 12,
+          :inline_format => true
 
-      @pdf.text event_type.elevator_pitch, :size => 10
+        @pdf.text event_type.elevator_pitch, :size => 10
 
-      @pdf.move_down 4.mm
+        @pdf.move_down 4.mm
+      end
     end
   end
 


### PR DESCRIPTION
As a reader of the PDF Catalog I want Workshop titles and descriptions to be kept in the same page to avoid confusion
